### PR TITLE
fix last point error

### DIFF
--- a/zigzag/core.pyx
+++ b/zigzag/core.pyx
@@ -115,10 +115,17 @@ cpdef peak_valley_pivots(double [:] X,
                 last_pivot_x = x
                 last_pivot_t = t
 
-    if last_pivot_t == t_n-1:
+    # if last_pivot_t == t_n-1:
+    #     pivots[last_pivot_t] = trend
+    # elif pivots[t_n-1] == 0:
+    #     pivots[t_n-1] = -trend
+    
+    # fix last point error 
+    if last_pivot_t > 0 and last_pivot_t < t_n-1:
         pivots[last_pivot_t] = trend
-    elif pivots[t_n-1] == 0:
         pivots[t_n-1] = -trend
+    else:
+        pivots[t_n-1] = trend
 
     return pivots
 


### PR DESCRIPTION
the code has some bugs for some test cases:
code:

a = np.array([1, 1.2, 1.5, 1.8, 2.4, 3.3, 2.4, 1.5, 1.6])
peak_valley_pivots(a, 0.2, -0.2)
# output (wrong result)
array([-1,  0,  0,  0,  0,  1,  0,  0,  1])

# output (after fix)
array([-1,  0,  0,  0,  0,  1,  0, -1,  1])